### PR TITLE
use nickel's rust-url version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,4 @@ path = "src/http/lib.rs"
 git = "https://github.com/sfackler/rust-openssl.git"
 
 [dependencies.url]
-git = "https://github.com/servo/rust-url"
+git = "https://github.com/nickel-org/rust-url"


### PR DESCRIPTION
This fixes the errors on nickel's build:
https://travis-ci.org/nickel-org/nickel.rs/builds/40414397

``` bash
src/query_string.rs:77:19: 77:43 error: mismatched types: expected `url::Url`, found `url::Url` (expected struct url::Url, found a different struct url::Url)
```
