### PR TITLE
Merge upstream

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,6 @@ git = "https://github.com/sfackler/rust-openssl.git"
 
 [dependencies.url]
 git = "https://github.com/nickel-org/rust-url"
+
+[dependencies.time]
+git = "https://github.com/rust-lang/time"

--- a/examples/apache_fake.rs
+++ b/examples/apache_fake.rs
@@ -35,7 +35,7 @@ impl Server for ApacheFakeServer {
             tm_wday: 4, // days since Sunday ~[0-6]
             tm_yday: 0, // days since January 1 ~[0-365]
             tm_isdst: 0, // Daylight Savings Time flag
-            tm_gmtoff: 0, // offset from UTC in seconds
+            tm_utcoff: 0, // offset from UTC in seconds
             tm_nsec: 0, // nanoseconds
         });
         w.headers.etag = Some(headers::etag::EntityTag {

--- a/src/http/client/sslclients/none.rs
+++ b/src/http/client/sslclients/none.rs
@@ -24,7 +24,7 @@ impl Connecter for NetworkStream {
                 detail: None,
             })
         } else {
-            let stream = try!(TcpStream::connect(format!("{}", addr.ip)[], addr.port));
+            let stream = try!(TcpStream::connect(addr));
             Ok(NormalStream(stream))
         }
     }

--- a/src/http/common.rs
+++ b/src/http/common.rs
@@ -5,7 +5,7 @@
  *
  * TODO: refactor all this to store things in more usefully categorised places.
  */
-use std::num::{Zero, cast};
+use std::num::{Unsigned, NumCast, Int, cast};
 use std::io::{IoError, IoResult, OtherIoError};
 #[cfg(test)]
 use std::io::MemReader;
@@ -43,13 +43,13 @@ const ASCII_UPPER_F: u8 = b'F';
  *
  * Should everything work as designed (i.e. none of these conditions occur) a `Some` is returned.
  */
-pub fn read_decimal<R: Reader, N: Unsigned + NumCast + PartialOrd + CheckedMul + CheckedAdd>
+pub fn read_decimal<R: Reader, N: Unsigned + NumCast + Int>
                    (reader: &mut R, expected_end: |u8| -> bool)
                    -> IoResult<N> {
     // Here and in `read_hexadecimal` there is the possibility of infinite sequence of zeroes. The
     // spec allows this, but it may not be a good thing to allow. It's not a particularly good
     // attack surface, though, because of the low return.
-    let mut n: N = Zero::zero();
+    let mut n: N = Int::zero();
     let mut got_content = false;
     let ten: N = cast(10u32).unwrap();
     loop {
@@ -58,8 +58,8 @@ pub fn read_decimal<R: Reader, N: Unsigned + NumCast + PartialOrd + CheckedMul +
                 // Written sanely, this is: n * 10 + (b - '0'), but we avoid
                 // (semantically unsound) overflow by using checked operations.
                 // There is no need in the b - '0' part as it is safe.
-                match n.checked_mul(&ten).and_then(
-                        |n| n.checked_add(&cast(b - ASCII_ZERO).unwrap())) {
+                match n.checked_mul(ten).and_then(
+                        |n| n.checked_add(cast(b - ASCII_ZERO).unwrap())) {
                     Some(new_n) => new_n,
                     None => return Err(bad_input()),  // overflow
                 }
@@ -89,31 +89,31 @@ pub fn read_decimal<R: Reader, N: Unsigned + NumCast + PartialOrd + CheckedMul +
  *
  * Should everything work as designed (i.e. none of these conditions occur) a `Some` is returned.
  */
-pub fn read_hexadecimal<R: Reader, N: Unsigned + NumCast + PartialOrd + CheckedMul + CheckedAdd>
+pub fn read_hexadecimal<R: Reader, N: Unsigned + NumCast + Int>
                        (reader: &mut R, expected_end: |u8| -> bool)
                        -> IoResult<N> {
-    let mut n: N = Zero::zero();
+    let mut n: N = Int::zero();
     let mut got_content = false;
     let sixteen: N = cast(16u32).unwrap();
     loop {
         n = match reader.read_byte() {
             Ok(b@ASCII_ZERO...ASCII_NINE) => {
-                match n.checked_mul(&sixteen).and_then(
-                        |n| n.checked_add(&cast(b - ASCII_ZERO).unwrap())) {
+                match n.checked_mul(sixteen).and_then(
+                        |n| n.checked_add(cast(b - ASCII_ZERO).unwrap())) {
                     Some(new_n) => new_n,
                     None => return Err(bad_input()),  // overflow
                 }
             },
             Ok(b@ASCII_LOWER_A...ASCII_LOWER_F) => {
-                match n.checked_mul(&sixteen).and_then(
-                        |n| n.checked_add(&cast(b - ASCII_LOWER_A + 10).unwrap())) {
+                match n.checked_mul(sixteen).and_then(
+                        |n| n.checked_add(cast(b - ASCII_LOWER_A + 10).unwrap())) {
                     Some(new_n) => new_n,
                     None => return Err(bad_input()),  // overflow
                 }
             },
             Ok(b@ASCII_UPPER_A...ASCII_UPPER_F) => {
-                match n.checked_mul(&sixteen).and_then(
-                        |n| n.checked_add(&cast(b - ASCII_UPPER_A + 10).unwrap())) {
+                match n.checked_mul(sixteen).and_then(
+                        |n| n.checked_add(cast(b - ASCII_UPPER_A + 10).unwrap())) {
                     Some(new_n) => new_n,
                     None => return Err(bad_input()),  // overflow
                 }

--- a/src/http/headers/mod.rs
+++ b/src/http/headers/mod.rs
@@ -792,7 +792,7 @@ mod test {
             tm_wday: 0,
             tm_yday: 0,
             tm_isdst: 0,
-            tm_gmtoff: 0,
+            tm_utcoff: 0,
             tm_nsec: 0
         }
     }


### PR DESCRIPTION
It seems like a few things were changed with rust and upstream was updated. Merging these changes allowed me to build rust-http locally. Locally I had to delete the libtime packages that were installed as part of the rust stdlib `sudo rm /usr/local/lib/rustlib/x86_64-apple-darwin/lib/libtime-4e7c5e5c.*` as it seems that libtime has been split into its own library.

I went down this path when my nickel build started failing, I double checked in my own nickel fork that nickel still builds.
